### PR TITLE
Avoid using Testdox format in PHPUnit

### DIFF
--- a/orbs/jobs.yml
+++ b/orbs/jobs.yml
@@ -132,12 +132,12 @@ jobs:
                   name: Library Tests
                   command: |
                       cd ~/workspace/vanilla
-                      ./vendor/bin/phpunit -c phpunit.xml.dist --exclude-group=ignore --testsuite="Library" --testdox
+                      ./vendor/bin/phpunit -c phpunit.xml.dist --exclude-group=ignore --testsuite="Library"
             - run:
                   name: APIv2 Tests
                   command: |
                       cd ~/workspace/vanilla
-                      ./vendor/bin/phpunit -c phpunit.xml.dist --exclude-group=ignore --testsuite="APIv2" --testdox
+                      ./vendor/bin/phpunit -c phpunit.xml.dist --exclude-group=ignore --testsuite="APIv2"
     php_73_lint:
         executor: core/php73
         steps: *php_lint_steps

--- a/orbs/jobs.yml
+++ b/orbs/jobs.yml
@@ -1,5 +1,5 @@
 version: 2.1
-publishVersion: 1.2.0
+publishVersion: 1.2.1
 name: "vanilla/jobs"
 description: "A set of jobs that vanilla needs to run"
 orbs:


### PR DESCRIPTION
The Testdox format can be a little hard to visually process in a build. This update avoids using it in favor of the default PHPUnit report format.