### PR TITLE
Revert testdox unit tests

### DIFF
--- a/orbs/core.yml
+++ b/orbs/core.yml
@@ -1,5 +1,5 @@
 version: 2.1
-publishVersion: 2.2.0
+publishVersion: 2.2.1
 name: "vanilla/core"
 description: "A set of executors and commands to build vanilla"
 aliases:

--- a/orbs/core.yml
+++ b/orbs/core.yml
@@ -98,4 +98,4 @@ commands:
                   name: Run Sphinx Test Group
                   command: |
                       cd ~/workspace/vanilla
-                      ./vendor/bin/phpunit -c phpunit.xml.dist --exclude-group=ignore --testsuite="Sphinx" --testdox
+                      ./vendor/bin/phpunit -c phpunit.xml.dist --exclude-group=ignore --testsuite="Sphinx"

--- a/orbs/jobs.yml
+++ b/orbs/jobs.yml
@@ -132,12 +132,12 @@ jobs:
                   name: Library Tests
                   command: |
                       cd ~/workspace/vanilla
-                      ./vendor/bin/phpunit -c phpunit.xml.dist --exclude-group=ignore --testsuite="Library" --testdox
+                      ./vendor/bin/phpunit -c phpunit.xml.dist --exclude-group=ignore --testsuite="Library"
             - run:
                   name: APIv2 Tests
                   command: |
                       cd ~/workspace/vanilla
-                      ./vendor/bin/phpunit -c phpunit.xml.dist --exclude-group=ignore --testsuite="APIv2" --testdox
+                      ./vendor/bin/phpunit -c phpunit.xml.dist --exclude-group=ignore --testsuite="APIv2"
     php_73_lint:
         executor: core/php73
         steps: *php_lint_steps

--- a/orbs/jobs.yml
+++ b/orbs/jobs.yml
@@ -1,5 +1,5 @@
 version: 2.1
-publishVersion: 1.2.0
+publishVersion: 1.2.1
 name: "vanilla/jobs"
 description: "A set of jobs that vanilla needs to run"
 orbs:


### PR DESCRIPTION
The testdox format makes it incredibly difficult to diagnosed failed tests within the test environment.

**Before testdox**

1. Look at console output.
2. Read failed tests or exceptions.

**After testdox**

1. Scroll through an endless list of tests.
2. Tests that were skipped and tests that failed are both equivalent.
3. Try and figure out what file the failed test is in. Nope.
4. Was an exception thrown? I can’t tell.

Pretty please, let’s revert this change. Devs can run testdox from their localhosts no problem.