### PR TITLE
Pin Circle CI node image to v12

### DIFF
--- a/orbs/core.yml
+++ b/orbs/core.yml
@@ -43,7 +43,7 @@ executors:
               environment: *db_env
     node:
         docker:
-            - image: circleci/node:lts-browsers
+            - image: circleci/node:12-browsers
 commands:
     checkout:
         description: "Clone necessary repos"

--- a/orbs/core.yml
+++ b/orbs/core.yml
@@ -1,5 +1,5 @@
 version: 2.1
-publishVersion: 2.2.2
+publishVersion: 2.2.3
 name: "vanilla/core"
 description: "A set of executors and commands to build vanilla"
 aliases:


### PR DESCRIPTION
The node executor provided by the core orb is currently set to be whatever the latest LTS of node is. I'm pinning it to v12, because there are currently issues with Vanilla builds and v14, the latest LTS.