### PR TITLE
Remove sphinx failing orb

### DIFF
--- a/orbs/jobs.yml
+++ b/orbs/jobs.yml
@@ -1,5 +1,5 @@
 version: 2.1
-publishVersion: 1.3.1
+publishVersion: 1.3.2
 name: "vanilla/jobs"
 description: "A set of jobs that vanilla needs to run"
 aliases:

--- a/orbs/jobs.yml
+++ b/orbs/jobs.yml
@@ -2,6 +2,8 @@ version: 2.1
 publishVersion: 1.3.2
 name: "vanilla/jobs"
 description: "A set of jobs that vanilla needs to run"
+orbs:
+    core: vanilla/core@2
 aliases:
     - &run_yarn
       run:

--- a/orbs/jobs.yml
+++ b/orbs/jobs.yml
@@ -2,8 +2,6 @@ version: 2.1
 publishVersion: 1.3.1
 name: "vanilla/jobs"
 description: "A set of jobs that vanilla needs to run"
-orbs:
-    core: vanilla/core@dev:feature/sphinx-support
 aliases:
     - &run_yarn
       run:


### PR DESCRIPTION
Removed the sphinx orb to resolve error: ```Error: The dev version of vanilla/core@dev:feature/sphinx-support has expired. Dev versions of orbs are only valid for 90 days after publishing.```

🚨🚨🚨🚨🚨 READ THIS 🚨🚨🚨🚨🚨

If you are updating one of the orbs in this repo be sure to update it's `publishVersion`.

If you ignore this step, THE PUBLISH WILL FAIL.
This can require some messy manual clenaup or re-incrementing the versions.
